### PR TITLE
Remove poor bank holidays support from pay-pagerduty

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,6 @@ Populate the `data/schedules.csv` and `data/users.csv` files by running the foll
 bundle exec ./bin/schedule -u -s
 ```
 
-Create a dummy bank holidays file (otherwise the scripts will fail):
-
-```
-echo '{ "events": [] }' > data/bank-holidays.json 
-```
-
 In `data/schedules.csv`, remove any schedules that are outside of your department, then add a `Type` column to the end. Each row should have a `Type` value of either `in_hours`, `out_of_hours`. If a given schedule is for both in-hours and out-of-hours, you'll need to run the scheduler twice, swapping out `in_hours` for `out_of_hours` and updating all the names.
 
 ## Usage

--- a/bin/schedule
+++ b/bin/schedule
@@ -72,7 +72,7 @@ if true
           ol['user']['summary'],
         )
       end
-      expected = Overrider.new(rotation, schedule_type, data_store.read_bank_holidays).overrides
+      expected = Overrider.new(rotation, schedule_type).overrides
 
       need_to_add = (expected - actuals)
       need_to_delete = (actuals - expected)
@@ -90,7 +90,7 @@ if true
 
         if cli.apply_overrides? || cli.dry_run?
           logger.warn "  Applying overrides"
-          overrides = Overrider.new(rotation, schedule_type, data_store.read_bank_holidays).overrides
+          overrides = Overrider.new(rotation, schedule_type).overrides
           overrides.each do |override|
             msg = "#{override.from.iso8601} - #{override.to.iso8601} - #{override.user_name} (#{override.user_id})"
             if cli.dry_run?

--- a/lib/data_store.rb
+++ b/lib/data_store.rb
@@ -39,9 +39,4 @@ class DataStore
   def read_schedules
     CSV.read(schedule_file, headers: true)
   end
-
-  def read_bank_holidays
-    data = File.read("#{path}bank-holidays.json")
-    JSON.parse(data).fetch("events").map { |e| Date.parse(e["date"]) }
-  end
 end

--- a/lib/overrider.rb
+++ b/lib/overrider.rb
@@ -4,12 +4,11 @@ require "active_support/core_ext/time/zones"
 require "override"
 
 class Overrider
-  attr_reader :rotation, :schedule_type, :bank_holidays
+  attr_reader :rotation, :schedule_type
 
-  def initialize(rotation, schedule_type, bank_holidays)
+  def initialize(rotation, schedule_type)
     @rotation = rotation
     @schedule_type = schedule_type
-    @bank_holidays = bank_holidays
   end
 
   def overrides
@@ -25,7 +24,6 @@ class Overrider
       (rotation.start_date...rotation.start_date + 7)
         .reject(&:saturday?)
         .reject(&:sunday?)
-        .reject { |date| bank_holiday?(date) }
         .map do |date|
           Time.use_zone("Europe/London") do
             Time.zone.parse("#{date}T09:30:00")
@@ -35,7 +33,6 @@ class Overrider
       (rotation.start_date...rotation.start_date + 7)
         .reject(&:saturday?)
         .reject(&:sunday?)
-        .reject { |date| bank_holiday?(date) }
         .map do |date|
           Time.use_zone("Europe/London") do
             Time.zone.parse("#{date}T17:30:00")
@@ -49,7 +46,6 @@ class Overrider
       (rotation.start_date...rotation.start_date + 7)
         .reject(&:saturday?)
         .reject(&:sunday?)
-        .reject { |date| bank_holiday?(date) }
         .map do |date|
           Time.use_zone("Europe/London") do
             Time.zone.parse("#{date}T17:30:00")
@@ -59,17 +55,12 @@ class Overrider
       (rotation.start_date + 1...rotation.start_date + 8)
         .reject(&:saturday?)
         .reject(&:sunday?)
-        .reject { |date| bank_holiday?(date) }
         .map do |date|
           Time.use_zone("Europe/London") do
             Time.zone.parse("#{date}T09:30:00")
           end
         end
     end
-  end
-
-  def bank_holiday?(date)
-    bank_holidays.include?(date)
   end
 
   def valid_schedule_type?

--- a/spec/overrider_spec.rb
+++ b/spec/overrider_spec.rb
@@ -6,7 +6,7 @@ require "overrider"
 require "override"
 
 RSpec.describe Overrider do
-  subject(:overrider) { described_class.new(rotation, schedule_type, bank_holidays) }
+  subject(:overrider) { described_class.new(rotation, schedule_type) }
 
   let(:start) { "2017-06-28" }
   let(:name) { "Ella Smith" }
@@ -14,7 +14,6 @@ RSpec.describe Overrider do
 
   let(:rotation) { Rotation.new(start, name, user_id) }
   let(:schedule_type) { :in_hours }
-  let(:bank_holidays) { [] }
 
   it "generates overrides from a rotation" do
     expect(overrider.overrides.size).to eq(5)
@@ -132,41 +131,6 @@ RSpec.describe Overrider do
     end
   end
 
-  context "when a rotation is overlapping a bank holiday" do
-    let(:start) { "2017-08-23" }
-    let(:bank_holidays) { [Date.parse("2017-08-28")] }
-
-    it "generates overrides from a rotation" do
-      expect(overrider.overrides.size).to eq(4)
-      expect(overrider.overrides).to eq([
-        Override.new(
-          DateTime.parse("2017-08-23T09:30:00+01:00"),
-          DateTime.parse("2017-08-23T17:30:00+01:00"),
-          user_id,
-          name,
-        ),
-        Override.new(
-          DateTime.parse("2017-08-24T09:30:00+01:00"),
-          DateTime.parse("2017-08-24T17:30:00+01:00"),
-          user_id,
-          name,
-        ),
-        Override.new(
-          DateTime.parse("2017-08-25T09:30:00+01:00"),
-          DateTime.parse("2017-08-25T17:30:00+01:00"),
-          user_id,
-          name,
-        ),
-        Override.new(
-          DateTime.parse("2017-08-29T09:30:00+01:00"),
-          DateTime.parse("2017-08-29T17:30:00+01:00"),
-          user_id,
-          name,
-        ),
-      ])
-    end
-  end
-
   context "when out of hours" do
     let(:schedule_type) { :out_of_hours }
 
@@ -239,41 +203,6 @@ RSpec.describe Overrider do
           Override.new(
             DateTime.parse("2017-03-28T17:30:00+01:00"),
             DateTime.parse("2017-03-29T09:30:00+01:00"),
-            user_id,
-            name,
-          ),
-        ])
-      end
-    end
-
-    context "when a rotation is overlapping a bank holiday" do
-      let(:start) { "2017-08-23" }
-      let(:bank_holidays) { [Date.parse("2017-08-28")] }
-
-      it "generates overrides from a rotation" do
-        expect(overrider.overrides.size).to eq(4)
-        expect(overrider.overrides).to eq([
-          Override.new(
-            DateTime.parse("2017-08-23T17:30:00+01:00"),
-            DateTime.parse("2017-08-24T09:30:00+01:00"),
-            user_id,
-            name,
-          ),
-          Override.new(
-            DateTime.parse("2017-08-24T17:30:00+01:00"),
-            DateTime.parse("2017-08-25T09:30:00+01:00"),
-            user_id,
-            name,
-          ),
-          Override.new(
-            DateTime.parse("2017-08-25T17:30:00+01:00"),
-            DateTime.parse("2017-08-29T09:30:00+01:00"),
-            user_id,
-            name,
-          ),
-          Override.new(
-            DateTime.parse("2017-08-29T17:30:00+01:00"),
-            DateTime.parse("2017-08-30T09:30:00+01:00"),
             user_id,
             name,
           ),


### PR DESCRIPTION
We’re moving towards a model where pay-pagerduty will contain less logic: its only job should be to take a bunch of names and dates, and synchronise those with PagerDuty. The bank holidays logic (if any) should be applied earlier on, in govuk-rota-generator, as part of generating said list of names and dates.

Trello: https://trello.com/c/SOD6gaCK/2013-remove-poor-bank-holidays-support-from-pay-pagerduty